### PR TITLE
Introduce changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+
+## [3.0.0] — 2025-03-21
+### Added
+- Documentation of new transformation rules and conventions for controlled
+  vocabularies ([Task 2: Export of controlled vocabulary
+  restrictions](https://github.com/OP-TED/model2owl/issues/228)) by @gkostkowski
+  in https://github.com/OP-TED/ted-model2owl-docs/pull/6
+- Documentation of new transformation rules and conventions for tags and
+  comments ([Task 3: Export of metadata about
+  concepts](https://github.com/OP-TED/model2owl/issues/229)) by @gkostkowski in
+  https://github.com/OP-TED/ted-model2owl-docs/pull/7
+- User guide providing general instructions and documenting new features ([Task
+  1: Status-based filtering](https://github.com/OP-TED/model2owl/issues/226),
+  [Task 2: Export of controlled vocabulary
+  restrictions](https://github.com/OP-TED/model2owl/issues/228), [Task 3: Export
+  of metadata about concepts](https://github.com/OP-TED/model2owl/issues/229))
+  by @Dragos0000 in https://github.com/OP-TED/ted-model2owl-docs/pull/9
+- Documentation of conventions and checkers for property inheritance
+  (https://github.com/OP-TED/model2owl/issues/205) by @gkostkowski in
+  https://github.com/OP-TED/ted-model2owl-docs/pull/10
+
+
+## [2.3.0-rc.1] — 2024-12-06
+### Changed
+- Cleaned-up the documentation structure
+- Fixed documentation version
+- Changed version number to correspond to the relevant [model2owl
+  version](https://github.com/OP-TED/model2owl/releases/tag/2.3.0-rc.2)


### PR DESCRIPTION
This change adds a dedicated changelog file to track modifications in the project. Going forward, release candidate versions will be documented in this changelog instead of using GitHub release pages.

The added file contains documentation of changes for past releases.